### PR TITLE
[Feat]: 편성 타일 버프 2종 구현, 파싱, 적용

### DIFF
--- a/Assets/_WorkSpace/KMT/02_SkillSystem/Scripts/StageCharacterSetter.cs
+++ b/Assets/_WorkSpace/KMT/02_SkillSystem/Scripts/StageCharacterSetter.cs
@@ -35,19 +35,19 @@ public class StageCharacterSetter : MonoBehaviour
         }
     }
 
-    public void InitCharacters(Dictionary<int, CharacterData> characterDatas)
+    public void InitCharacters(Dictionary<int, CharacterData> characterDatas, List<StageData.BuffInfo> tileBuff)
     {
         if (characterDatas.Count <= 0)
             return;
 
         GetComponent<CombManager>().ListClearedEvent.AddListener(() => { Debug.Log("전☆멸"); });
 
-        SpawnCharacterDataSet(characterDatas);
+        SpawnCharacterDataSet(characterDatas, tileBuff);
 
     }
 
 
-    private void SpawnCharacterDataSet(Dictionary<int, CharacterData> characterDataList)
+    private void SpawnCharacterDataSet(Dictionary<int, CharacterData> characterDataList, List<StageData.BuffInfo> tileBuff)
     {
         CombManager group = GetComponent<CombManager>();
         List<Combatable> characters = new List<Combatable>();
@@ -64,8 +64,14 @@ public class StageCharacterSetter : MonoBehaviour
                             Instantiate(basicSkillButtonPrefab, skillPanel.transform),
                             Instantiate(secondSkillButtonPrefab, secondSkillPanel.transform));
 
-
-
+            foreach (StageData.BuffInfo buffInfo in tileBuff)
+            {
+                if (pair.Key == buffInfo.tileIndex)
+                {
+                    // 편성 위치가 버프 적용 대상 타일일 경우 버프 적용
+                    charObj.StatusBuffed(buffInfo.type, buffInfo.value);
+                }
+            }
         }
 
         GetComponent<CombManager>().CharList = characters;

--- a/Assets/_WorkSpace/KMT/02_SkillSystem/Scripts/StageManager.cs
+++ b/Assets/_WorkSpace/KMT/02_SkillSystem/Scripts/StageManager.cs
@@ -106,7 +106,7 @@ public class StageManager : MonoBehaviour
                 GameManager.TableData.GetCharacterData((int)pair.Value);
         }
 
-        characterSetter.InitCharacters(batchDictionary);
+        characterSetter.InitCharacters(batchDictionary, _stageData.TileBuff);
         characterManager.ListClearedEvent.AddListener(OnDefeat);
 
         // ============= 몬스터 캐릭터 초기화 =============

--- a/Assets/_WorkSpace/KMT/Test_Kmt/Scripts/Combatable.cs
+++ b/Assets/_WorkSpace/KMT/Test_Kmt/Scripts/Combatable.cs
@@ -159,6 +159,22 @@ public class Combatable : MonoBehaviour
 
     }
 
+    public void StatusBuffed(StatusBuffType type, float value)
+    {
+        switch (type)
+        {
+            case StatusBuffType.ATK_PERCENTAGE:
+                attackPoint.Value *= (1f + value * 0.01f);
+                break;
+            case StatusBuffType.DEF_PERCENTAGE:
+                defense.Value *= (1f + value * 0.01f);
+                break;
+            default:
+                Debug.LogWarning("잘못되었거나 정의되지 않은 버프 타입");
+                break;
+        }
+    }
+
     public void Damaged(float damage, float igDefRate)
     {
         if (!IsAlive)

--- a/Assets/_WorkSpace/Scripts/StageData.cs
+++ b/Assets/_WorkSpace/Scripts/StageData.cs
@@ -20,8 +20,16 @@ public class StageDataDataEditor : Editor
 }
 #endif
 
+public enum StatusBuffType : int
+{
+    ERROR,
+    ATK_PERCENTAGE,
+    DEF_PERCENTAGE,
+}
+
 public class StageData : ScriptableObject, ICsvMultiRowParseable
 {
+
     /// <summary>
     /// 각 스테이지의 고유 번호
     /// </summary>
@@ -43,6 +51,11 @@ public class StageData : ScriptableObject, ICsvMultiRowParseable
     public List<ItemGain> Reward => reward;
 
     /// <summary>
+    /// 편성 칸에 적용되는 버프 목록
+    /// </summary>
+    public List<BuffInfo> TileBuff => tileBuff;
+
+    /// <summary>
     /// (유저 데이터) 클리어 횟수
     /// </summary>
     public UserDataInt ClearCount { get; private set; }
@@ -57,6 +70,8 @@ public class StageData : ScriptableObject, ICsvMultiRowParseable
     [SerializeField] List<WaveInfo> waves;
 
     [SerializeField] List<ItemGain> reward;
+
+    [SerializeField] List<BuffInfo> tileBuff;
 
     private void OnEnable()
     {
@@ -88,6 +103,16 @@ public class StageData : ScriptableObject, ICsvMultiRowParseable
         public Vector2 pose;
     }
 
+
+
+    [System.Serializable]
+    public struct BuffInfo
+    {
+        public StatusBuffType type;
+        public float value;
+        public int tileIndex;
+    }
+
 #if UNITY_EDITOR
     private enum Column
     {
@@ -107,6 +132,11 @@ public class StageData : ScriptableObject, ICsvMultiRowParseable
 
         REWARD_NAME,
         REWARD_NUMBER,
+
+        DROPDOWN_BUFF_TYPE,
+        BUFF_TYPE,
+        BUFF_VALUE,
+        BUFF_TILE_INDEX,
 
     }
 
@@ -130,6 +160,7 @@ public class StageData : ScriptableObject, ICsvMultiRowParseable
 
                 waves = new List<WaveInfo>();
                 reward = new List<ItemGain>();
+                tileBuff = new List<BuffInfo>();
 
                 // NAME
                 stageName = cells[(int)Column.STAGE_NAME];
@@ -192,6 +223,27 @@ public class StageData : ScriptableObject, ICsvMultiRowParseable
                 }
 
                 reward.Add(rewardInfo);
+            }
+
+            // 현재 행에 버프 정보가 있다면 추가
+            if (int.TryParse(cells[(int)Column.BUFF_TYPE], out int buffType))
+            {
+                BuffInfo buffInfo = new BuffInfo();
+                buffInfo.type = (StatusBuffType)buffType;
+
+                if (false == float.TryParse(cells[(int)Column.BUFF_VALUE], out buffInfo.value))
+                {
+                    Debug.LogError($"잘못된 데이터로 갱신 시도됨");
+                    continue;
+                }
+
+                if (false == int.TryParse(cells[(int)Column.BUFF_TILE_INDEX], out buffInfo.tileIndex))
+                {
+                    Debug.LogError($"잘못된 데이터로 갱신 시도됨");
+                    continue;
+                }
+
+                tileBuff.Add(buffInfo);
             }
 
             line++;


### PR DESCRIPTION
스테이지 데이터 시트에서 버프 종류, 버프 수치, 적용 타일을 선택해 버프를 추가 가능합니다
버프 종류를 늘릴 때 마다 Combatable에 코드 작업 필요