### PR TITLE
[Feat]: 로비 레이아웃 재배치 및 씬 분리 적용

### DIFF
--- a/Assets/_WorkSpace/CJS/LobbyScene.cs
+++ b/Assets/_WorkSpace/CJS/LobbyScene.cs
@@ -9,17 +9,17 @@ public class LobbyScene : MonoBehaviour
     [System.Serializable]
     private struct ChildUIField
     {
-        public Button charactersButton;
-        public Button achievementButton;
-        public Button storyButton;
-        public Button shopButton;
-        public Button myRoomButton;
-        public Button advantureButton;
+        [EnumNamedArray(typeof(GameManager.MenuType))]
+        public List<Button> menuSceneButtons;
     }
     [SerializeField] ChildUIField childUIField;
 
     private void Awake()
     {
-
+        for (int i = 0; i < childUIField.menuSceneButtons.Count; i++)
+        {
+            GameManager.MenuType menu = (GameManager.MenuType)i;
+            childUIField.menuSceneButtons[i].onClick.AddListener(() => GameManager.Instance.LoadMenuScene(menu));
+        }
     }
 }

--- a/Assets/_WorkSpace/CJS/OutskirtsUI.cs
+++ b/Assets/_WorkSpace/CJS/OutskirtsUI.cs
@@ -38,34 +38,9 @@ public class OutskirtsUI : MonoBehaviour
     public Button QuickMoveMenuButton => childUIField.quickMoveMenuButton;
 
     /// <summary>
-    /// 캐릭터 창 빠른 이동 버튼
+    /// 빠른 이동 버튼 리스트
     /// </summary>
-    public Button CharactersButton => childUIField.charactersButton;
-
-    /// <summary>
-    /// 엄적 창 빠른 이동 버튼
-    /// </summary>
-    public Button AchievementButton => childUIField.achievementButton;
-
-    /// <summary>
-    /// 스토리 창 빠른 이동 버튼
-    /// </summary>
-    public Button StoryButton => childUIField.storyButton;
-
-    /// <summary>
-    /// 상점 창 빠른 이동 버튼
-    /// </summary>
-    public Button ShopButton => childUIField.shopButton;
-
-    /// <summary>
-    /// 나만의 공간 빠른 이동 버튼
-    /// </summary>
-    public Button MyRoomButton => childUIField.myRoomButton;
-
-    /// <summary>
-    /// 모험 창 빠른 이동 버튼
-    /// </summary>
-    public Button AdvantureButton => childUIField.advantureButton;
+    public List<Button> MenuSceneButtons => childUIField.menuSceneButtons;
 
     [System.Serializable]
     private struct ChildUIField
@@ -75,26 +50,31 @@ public class OutskirtsUI : MonoBehaviour
         public Button homeButton;
         public Button quickMoveMenuButton;
         public LayoutGroup quickMoveLayout;
-        public Button charactersButton;
-        public Button achievementButton;
-        public Button storyButton;
-        public Button shopButton;
-        public Button myRoomButton;
-        public Button advantureButton;
+        [EnumNamedArray(typeof(GameManager.MenuType))]
+        public List<Button> menuSceneButtons;
     }
     [SerializeField] ChildUIField childUIField;
 
-    private bool quickMoveToggleState = false;
+    private bool quickMoveToggleState;
 
     private void Awake()
     {
+        quickMoveToggleState = childUIField.quickMoveLayout.gameObject.activeSelf;
         QuickMoveMenuButton.onClick.AddListener(ToggleQuickMove);
 
         ReturnButton.onClick.AddListener(OnReturnButtonClicked);
         // 다른 팝업으로 가려졌을때는 동작하지 않아야 함
         //GameManager.Input.actions["Cancel"].started += OnReturnButtonClicked;
 
+        // 홈 버튼에 씬 전환 등록
         HomeButton.onClick.AddListener(OnHomeButtonClicked);
+
+        // 각 빠른이동 버튼에 해당 씬 전환 함수 등록
+        for (int i = 0; i < childUIField.menuSceneButtons.Count; i++)
+        {
+            GameManager.MenuType menu = (GameManager.MenuType)i;
+            childUIField.menuSceneButtons[i].onClick.AddListener(() => GameManager.Instance.LoadMenuScene(menu));
+        }
     }
 
     private void ToggleQuickMove()
@@ -129,6 +109,6 @@ public class OutskirtsUI : MonoBehaviour
 
     private void OnHomeButtonClicked()
     {
-        GameManager.Instance.LoadMainScene();
+        GameManager.Instance.LoadLobbyScene();
     }
 }

--- a/Assets/_WorkSpace/Prefabs/UI Canvas/Outskirts UI.prefab
+++ b/Assets/_WorkSpace/Prefabs/UI Canvas/Outskirts UI.prefab
@@ -1944,12 +1944,13 @@ MonoBehaviour:
     homeButton: {fileID: 1156560379211867086}
     quickMoveMenuButton: {fileID: 1156560379604131198}
     quickMoveLayout: {fileID: 1156560379727867880}
-    charactersButton: {fileID: 1156560381215129733}
-    achievementButton: {fileID: 1156560380511829624}
-    storyButton: {fileID: 1156560380958460572}
-    shopButton: {fileID: 1156560380653046320}
-    myRoomButton: {fileID: 1156560379894912552}
-    advantureButton: {fileID: 1156560380558345501}
+    menuSceneButtons:
+    - {fileID: 1156560381215129733}
+    - {fileID: 1156560380511829624}
+    - {fileID: 1156560380958460572}
+    - {fileID: 1156560380653046320}
+    - {fileID: 1156560379894912552}
+    - {fileID: 1156560380558345501}
 --- !u!1 &1156560380749500439
 GameObject:
   m_ObjectHideFlags: 0
@@ -2276,7 +2277,7 @@ GameObject:
   - component: {fileID: 1156560380995313124}
   - component: {fileID: 1156560380995313127}
   m_Layer: 5
-  m_Name: Text (TMP)
+  m_Name: Scene Title
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/_WorkSpace/Resources/GameManager.prefab
+++ b/Assets/_WorkSpace/Resources/GameManager.prefab
@@ -74,13 +74,13 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3481628369008611473}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1595156160372659494}
-  m_Father: {fileID: 551778546804259337}
+  m_Father: {fileID: 1811466336765316488}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -344,6 +344,45 @@ MonoBehaviour:
   m_DeselectOnBackgroundClick: 1
   m_PointerBehavior: 0
   m_CursorLockBehavior: 0
+--- !u!1 &6056045412517326008
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1811466336765316488}
+  m_Layer: 0
+  m_Name: Toggle Overlay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1811466336765316488
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6056045412517326008}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8213823266653518347}
+  - {fileID: 5852693435064159794}
+  - {fileID: 6884007505089496661}
+  m_Father: {fileID: 551778546804259337}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &6219096150680691296
 GameObject:
   m_ObjectHideFlags: 0
@@ -437,7 +476,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f0d82e5412509574888b4da81a14e203, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  popupCanvas: {fileID: 551778546804259337}
+  popupCanvas: {fileID: 7565941345072365108}
   shortLoadingPanel: {fileID: 8213823266653518347}
 --- !u!114 &1605335224699957630
 MonoBehaviour:
@@ -502,9 +541,8 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 8213823266653518347}
-  - {fileID: 5852693435064159794}
-  - {fileID: 6884007505089496661}
+  - {fileID: 7565941345072365108}
+  - {fileID: 1811466336765316488}
   m_Father: {fileID: 5725828354025764271}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -591,6 +629,42 @@ MonoBehaviour:
     type: 3}
   simpleInfoUI: {fileID: 5852693435064159804}
   doubleInfoUI: {fileID: 3337107053513863856}
+--- !u!1 &7254018432412064755
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7565941345072365108}
+  m_Layer: 0
+  m_Name: Instance Overlay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7565941345072365108
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7254018432412064755}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 551778546804259337}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &7422888708328105519
 GameObject:
   m_ObjectHideFlags: 0
@@ -855,7 +929,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 551778546804259337}
+    m_TransformParent: {fileID: 1811466336765316488}
     m_Modifications:
     - target: {fileID: 842276534367234244, guid: 2074dce0cf45b3d419649a36006ddf50,
         type: 3}
@@ -985,7 +1059,7 @@ PrefabInstance:
     - target: {fileID: 842276534873233858, guid: 2074dce0cf45b3d419649a36006ddf50,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -0.000061035156
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 842276534873233858, guid: 2074dce0cf45b3d419649a36006ddf50,
         type: 3}
@@ -1037,7 +1111,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 551778546804259337}
+    m_TransformParent: {fileID: 1811466336765316488}
     m_Modifications:
     - target: {fileID: 842276534367234244, guid: 86b40ff8f7a64e44196b55a03f6a83c3,
         type: 3}
@@ -1137,17 +1211,17 @@ PrefabInstance:
     - target: {fileID: 842276534873233858, guid: 86b40ff8f7a64e44196b55a03f6a83c3,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 842276534873233858, guid: 86b40ff8f7a64e44196b55a03f6a83c3,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 842276534873233858, guid: 86b40ff8f7a64e44196b55a03f6a83c3,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 842276534873233858, guid: 86b40ff8f7a64e44196b55a03f6a83c3,
         type: 3}

--- a/Assets/_WorkSpace/Scenes/AdvantureMenuScene.unity
+++ b/Assets/_WorkSpace/Scenes/AdvantureMenuScene.unity
@@ -1735,25 +1735,30 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1156560380558345502, guid: 807696051b4f477499fe73bb6e595fba,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1156560380558345503, guid: 807696051b4f477499fe73bb6e595fba,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1156560380558345503, guid: 807696051b4f477499fe73bb6e595fba,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1156560380558345503, guid: 807696051b4f477499fe73bb6e595fba,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 859.452
       objectReference: {fileID: 0}
     - target: {fileID: 1156560380558345503, guid: 807696051b4f477499fe73bb6e595fba,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -62.5
       objectReference: {fileID: 0}
     - target: {fileID: 1156560380653046322, guid: 807696051b4f477499fe73bb6e595fba,
         type: 3}
@@ -1904,6 +1909,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1156560380995313127, guid: 807696051b4f477499fe73bb6e595fba,
+        type: 3}
+      propertyPath: m_text
+      value: "\uBAA8\uD5D8"
       objectReference: {fileID: 0}
     - target: {fileID: 1156560381215129735, guid: 807696051b4f477499fe73bb6e595fba,
         type: 3}

--- a/Assets/_WorkSpace/Scenes/LobbyScene.unity
+++ b/Assets/_WorkSpace/Scenes/LobbyScene.unity
@@ -290,12 +290,13 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   childUIField:
-    charactersButton: {fileID: 0}
-    achievementButton: {fileID: 0}
-    storyButton: {fileID: 0}
-    shopButton: {fileID: 0}
-    myRoomButton: {fileID: 0}
-    advantureButton: {fileID: 0}
+    menuSceneButtons:
+    - {fileID: 7050697331420223334}
+    - {fileID: 7050697330985806235}
+    - {fileID: 7050697331751476607}
+    - {fileID: 7050697330908667347}
+    - {fileID: 7050697330670682571}
+    - {fileID: 7050697331082924798}
 --- !u!1 &2007748785
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_WorkSpace/Scripts/Editors/EnumNamedArrayAttribute.cs
+++ b/Assets/_WorkSpace/Scripts/Editors/EnumNamedArrayAttribute.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+public class EnumNamedArrayAttribute : PropertyAttribute
+{
+    public string[] names;
+
+    public EnumNamedArrayAttribute(System.Type names_enum_type)
+    {
+        this.names = System.Enum.GetNames(names_enum_type);
+    }
+}
+
+[CustomPropertyDrawer(typeof(EnumNamedArrayAttribute))]
+public class DrawerEnumNamedArray : PropertyDrawer
+{
+
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        EnumNamedArrayAttribute enumNames = attribute as EnumNamedArrayAttribute;
+
+        //propertyPath returns something like component_hp_max.Array.data[4]
+        //so get the index from there
+        int index = System.Convert.ToInt32(property.propertyPath.Substring(property.propertyPath.IndexOf("[")).Replace("[", "").Replace("]", ""));
+
+        if (index < enumNames.names.Length)
+        {
+            //change the label
+            label.text = enumNames.names[index];
+        }
+        else
+        {
+            // enum 값이 지정되지 않은 경우
+            label.text = $"_{index}(undef enum)";
+        }
+
+        //draw field
+        EditorGUI.PropertyField(position, property, label, true);
+
+    }
+}

--- a/Assets/_WorkSpace/Scripts/Editors/EnumNamedArrayAttribute.cs.meta
+++ b/Assets/_WorkSpace/Scripts/Editors/EnumNamedArrayAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0bc7299c5a9987b46bc24b33f3b15855
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_WorkSpace/Scripts/GameManager.cs
+++ b/Assets/_WorkSpace/Scripts/GameManager.cs
@@ -87,12 +87,38 @@ public class GameManager : SingletonBehaviour<GameManager>
     /// </summary>
     public enum MenuType { CHARACTERS, ACHIEVEMENT, STORY, SHOP, MYROOM, ADVANTURE, }
 
+    public void LoadLobbyScene()
+    {
+        SceneManager.LoadSceneAsync("LobbyScene");
+    }
+
     /// <summary>
     /// 지정된 메뉴로 이동
     /// </summary>
     /// <param name="menu"></param>
     public void LoadMenuScene(MenuType menu)
     {
+        Debug.Log($"{menu} 메뉴 씬으로 이동 호출됨");
+
+        string sceneName;
+        switch (menu)
+        {
+            case MenuType.CHARACTERS:
+            case MenuType.ACHIEVEMENT:
+            case MenuType.STORY:
+            case MenuType.SHOP:
+            case MenuType.MYROOM:
+                Debug.LogWarning("아직 씬이 준비되지 않음");
+                return;
+                break;
+            case MenuType.ADVANTURE:
+                sceneName = "AdvantureMenuScene";
+                break;
+            default:
+                Debug.LogWarning($"잘못된 MenuType: {menu}");
+                return;
+        }
+        SceneManager.LoadSceneAsync(sceneName);
 
     }
 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -7,7 +7,13 @@ EditorBuildSettings:
   m_Scenes:
   - enabled: 1
     path: Assets/_WorkSpace/Scenes/LoginSelection.unity
-    guid: 7faa41501d30ccd4aa1a27302206a181
+    guid: ea11cc93c8a821f448ec7c08b1cba7f4
+  - enabled: 1
+    path: Assets/_WorkSpace/Scenes/LobbyScene.unity
+    guid: bd5b34957d2fd3b4b84c13af565a7497
+  - enabled: 1
+    path: Assets/_WorkSpace/Scenes/AdvantureMenuScene.unity
+    guid: 50b467491b916bb4fa6426bc0fdf6f2c
   - enabled: 1
     path: Assets/_WorkSpace/Scenes/MainMenu.unity
     guid: 48227c928d20b3a468fa2d16a7b1c15d
@@ -20,9 +26,6 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/_WorkSpace/Scenes/StageDefault.unity
     guid: b97da415c0c655244b1e66a97224e98b
-  - enabled: 1
-    path: Assets/_WorkSpace/Scenes/AdvantureMenuScene.unity
-    guid: 50b467491b916bb4fa6426bc0fdf6f2c
   - enabled: 1
     path: Assets/_WorkSpace/HYJ_Test/Scenes/HYJ_BattleFormation.unity
     guid: 543ff777b0471a344b2c9c9975dee723


### PR DESCRIPTION
빠른이동 메뉴의 각 버튼에 코드를 통해 `GameManager.LoadMenuScene()` 함수 구독되어있음