### PR TITLE
[Fix]: 프리펩에서 플레이어 캐릭터 위치 조정 및 생성시 회전 조정

### DIFF
--- a/Assets/_WorkSpace/KMT/Test_Kmt/Scripts/Combatable.cs
+++ b/Assets/_WorkSpace/KMT/Test_Kmt/Scripts/Combatable.cs
@@ -7,8 +7,6 @@ using UniRx;
 using Unity.Mathematics;
 using UnityEngine.UI;
 using UnityEngine.AI;
-using Spine;
-using Unity.IO.LowLevel.Unsafe;
 
 [RequireComponent(typeof(NavMeshAgent))]
 public class Combatable : MonoBehaviour
@@ -160,7 +158,7 @@ public class Combatable : MonoBehaviour
 
         // 외형 생성
         characterModel = Instantiate(modelData, transform);
-        characterModel.transform.rotation = Quaternion.Euler(90, 0, 0);
+        characterModel.transform.RotateAround(this.transform.position, this.transform.right, 90f); // xz 평면에 놓이도록 조정
         CharacterSizeRadius = characterModel.ModelSize;
         characterModel.name = "Model";
         if (false == characterModel.TryGetComponent(out Animator animator))

--- a/Assets/_WorkSpace/Prefabs/PlayerCharacters/BlackDragon.prefab
+++ b/Assets/_WorkSpace/Prefabs/PlayerCharacters/BlackDragon.prefab
@@ -55,12 +55,12 @@ PrefabInstance:
     - target: {fileID: -7552582706839291426, guid: 0e7febd0d325ea442a52a9d38c72f365,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 0.8
       objectReference: {fileID: 0}
     - target: {fileID: -7552582706839291426, guid: 0e7febd0d325ea442a52a9d38c72f365,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -7552582706839291426, guid: 0e7febd0d325ea442a52a9d38c72f365,
         type: 3}
@@ -110,7 +110,7 @@ PrefabInstance:
     - target: {fileID: -587020401536548690, guid: 0e7febd0d325ea442a52a9d38c72f365,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: -0.0029859543
+      value: -0.0029850006
       objectReference: {fileID: 0}
     - target: {fileID: -587020401536548690, guid: 0e7febd0d325ea442a52a9d38c72f365,
         type: 3}
@@ -165,7 +165,7 @@ PrefabInstance:
     - target: {fileID: 3458939219845311056, guid: 0e7febd0d325ea442a52a9d38c72f365,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: 0.000019550323
+      value: 0.00002002716
       objectReference: {fileID: 0}
     - target: {fileID: 8786841846783098033, guid: 0e7febd0d325ea442a52a9d38c72f365,
         type: 3}
@@ -175,7 +175,7 @@ PrefabInstance:
     - target: {fileID: 8786841846783098033, guid: 0e7febd0d325ea442a52a9d38c72f365,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: 0.000024437904
+      value: 0.000024914742
       objectReference: {fileID: 0}
     - target: {fileID: 8786841846783098033, guid: 0e7febd0d325ea442a52a9d38c72f365,
         type: 3}

--- a/Assets/_WorkSpace/Prefabs/PlayerCharacters/PinkDragon.prefab
+++ b/Assets/_WorkSpace/Prefabs/PlayerCharacters/PinkDragon.prefab
@@ -121,12 +121,12 @@ PrefabInstance:
     - target: {fileID: -8123559110241969439, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
       propertyPath: m_Bounds.m_Center.x
-      value: 0.00008106232
+      value: 0.00002002716
       objectReference: {fileID: 0}
     - target: {fileID: -8123559110241969439, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: 0.00010108948
+      value: 0.000104904175
       objectReference: {fileID: 0}
     - target: {fileID: -8123559110241969439, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
@@ -196,7 +196,7 @@ PrefabInstance:
     - target: {fileID: -7552582706839291426, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4.02
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -7552582706839291426, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
@@ -316,32 +316,32 @@ PrefabInstance:
     - target: {fileID: -587020401536548690, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
       propertyPath: m_Bounds.m_Center.x
-      value: -0.0002002716
+      value: -0.00019979477
       objectReference: {fileID: 0}
     - target: {fileID: -587020401536548690, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: -0.0024359226
+      value: -0.0024363995
       objectReference: {fileID: 0}
     - target: {fileID: -587020401536548690, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
       propertyPath: m_Bounds.m_Extent.x
-      value: 4.9092107
+      value: 4.909211
       objectReference: {fileID: 0}
     - target: {fileID: -587020401536548690, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
       propertyPath: m_Bounds.m_Extent.y
-      value: 3.982569
+      value: 3.9825647
       objectReference: {fileID: 0}
     - target: {fileID: -198828038849347438, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
       propertyPath: m_Bounds.m_Center.x
-      value: 0.00004386902
+      value: 0.00010442734
       objectReference: {fileID: 0}
     - target: {fileID: -198828038849347438, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: 0
+      value: 0.00000023841858
       objectReference: {fileID: 0}
     - target: {fileID: -198828038849347438, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
@@ -376,7 +376,7 @@ PrefabInstance:
     - target: {fileID: 135192302097971356, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
       propertyPath: m_Bounds.m_Center.x
-      value: 0.00009012222
+      value: 0.000030040741
       objectReference: {fileID: 0}
     - target: {fileID: 135192302097971356, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
@@ -386,12 +386,12 @@ PrefabInstance:
     - target: {fileID: 135192302097971356, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
       propertyPath: m_Bounds.m_Extent.x
-      value: 6.09497
+      value: 6.0949707
       objectReference: {fileID: 0}
     - target: {fileID: 135192302097971356, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
       propertyPath: m_Bounds.m_Extent.y
-      value: 3.4750004
+      value: 3.475
       objectReference: {fileID: 0}
     - target: {fileID: 311580695235782034, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
@@ -506,7 +506,7 @@ PrefabInstance:
     - target: {fileID: 3458939219845311056, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: -0.000013947487
+      value: -0.00001013279
       objectReference: {fileID: 0}
     - target: {fileID: 3458939219845311056, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
@@ -661,12 +661,12 @@ PrefabInstance:
     - target: {fileID: 8786841846783098033, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
       propertyPath: m_Bounds.m_Center.x
-      value: 0.00007510185
+      value: 0.00007426739
       objectReference: {fileID: 0}
     - target: {fileID: 8786841846783098033, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: -0.000013947487
+      value: -0.00001013279
       objectReference: {fileID: 0}
     - target: {fileID: 8786841846783098033, guid: 9507a65b342a7d64e835c2a30bcfb804,
         type: 3}

--- a/Assets/_WorkSpace/Prefabs/PlayerCharacters/SoulDragon2.prefab
+++ b/Assets/_WorkSpace/Prefabs/PlayerCharacters/SoulDragon2.prefab
@@ -12,6 +12,46 @@ PrefabInstance:
       propertyPath: m_Name
       value: SoulDragon2
       objectReference: {fileID: 0}
+    - target: {fileID: -8123559110241969439, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Center.x
+      value: -0.08955252
+      objectReference: {fileID: 0}
+    - target: {fileID: -8123559110241969439, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Center.y
+      value: 0.1309967
+      objectReference: {fileID: 0}
+    - target: {fileID: -8123559110241969439, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Extent.x
+      value: 1.7927203
+      objectReference: {fileID: 0}
+    - target: {fileID: -8123559110241969439, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Extent.y
+      value: 3.2415218
+      objectReference: {fileID: 0}
+    - target: {fileID: -7578943176630698069, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Center.x
+      value: 1.0011945
+      objectReference: {fileID: 0}
+    - target: {fileID: -7578943176630698069, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Center.y
+      value: -2.1000443
+      objectReference: {fileID: 0}
+    - target: {fileID: -7578943176630698069, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Extent.x
+      value: 5.8883677
+      objectReference: {fileID: 0}
+    - target: {fileID: -7578943176630698069, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Extent.y
+      value: 2.080132
+      objectReference: {fileID: 0}
     - target: {fileID: -7552582706839291426, guid: 4886586331cc1134084e1f7835c61a0b,
         type: 3}
       propertyPath: m_RootOrder
@@ -86,6 +126,126 @@ PrefabInstance:
         type: 3}
       propertyPath: m_ConstrainProportionsScale
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -6367637884826946392, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Center.x
+      value: 2.1023147
+      objectReference: {fileID: 0}
+    - target: {fileID: -6367637884826946392, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Center.y
+      value: -3.0178175
+      objectReference: {fileID: 0}
+    - target: {fileID: -6367637884826946392, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Extent.x
+      value: 4.8871365
+      objectReference: {fileID: 0}
+    - target: {fileID: -6367637884826946392, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Extent.y
+      value: 1.9110664
+      objectReference: {fileID: 0}
+    - target: {fileID: -587020401536548690, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Center.x
+      value: -0.12807941
+      objectReference: {fileID: 0}
+    - target: {fileID: -587020401536548690, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Center.y
+      value: 0.18146038
+      objectReference: {fileID: 0}
+    - target: {fileID: -587020401536548690, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Extent.x
+      value: 4.3871565
+      objectReference: {fileID: 0}
+    - target: {fileID: -587020401536548690, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Extent.y
+      value: 4.6856723
+      objectReference: {fileID: 0}
+    - target: {fileID: -198828038849347438, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Center.x
+      value: -0.37819088
+      objectReference: {fileID: 0}
+    - target: {fileID: -198828038849347438, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Center.y
+      value: 0.40944386
+      objectReference: {fileID: 0}
+    - target: {fileID: -198828038849347438, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Extent.x
+      value: 1.9221431
+      objectReference: {fileID: 0}
+    - target: {fileID: -198828038849347438, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Extent.y
+      value: 3.002227
+      objectReference: {fileID: 0}
+    - target: {fileID: 135192302097971356, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Center.x
+      value: 12.442364
+      objectReference: {fileID: 0}
+    - target: {fileID: 135192302097971356, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Center.y
+      value: 1.1985688
+      objectReference: {fileID: 0}
+    - target: {fileID: 135192302097971356, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Extent.x
+      value: 15.527075
+      objectReference: {fileID: 0}
+    - target: {fileID: 135192302097971356, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Extent.y
+      value: 4.8167624
+      objectReference: {fileID: 0}
+    - target: {fileID: 3458939219845311056, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Center.x
+      value: -0.0004608631
+      objectReference: {fileID: 0}
+    - target: {fileID: 3458939219845311056, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Center.y
+      value: 0.19617736
+      objectReference: {fileID: 0}
+    - target: {fileID: 3458939219845311056, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Extent.x
+      value: 2.5001783
+      objectReference: {fileID: 0}
+    - target: {fileID: 3458939219845311056, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Extent.y
+      value: 1.9045854
+      objectReference: {fileID: 0}
+    - target: {fileID: 8786841846783098033, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Center.x
+      value: 0.040840507
+      objectReference: {fileID: 0}
+    - target: {fileID: 8786841846783098033, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Center.y
+      value: 0.25206208
+      objectReference: {fileID: 0}
+    - target: {fileID: 8786841846783098033, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Extent.x
+      value: 1.5017813
+      objectReference: {fileID: 0}
+    - target: {fileID: 8786841846783098033, guid: 4886586331cc1134084e1f7835c61a0b,
+        type: 3}
+      propertyPath: m_Bounds.m_Extent.y
+      value: 2.1981947
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 4843985084834002234, guid: 4886586331cc1134084e1f7835c61a0b,

--- a/Assets/_WorkSpace/Prefabs/PlayerCharacters/YellowDragon3.prefab
+++ b/Assets/_WorkSpace/Prefabs/PlayerCharacters/YellowDragon3.prefab
@@ -323,22 +323,22 @@ PrefabInstance:
     - target: {fileID: -8123559110241969439, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Center.x
-      value: 9.894533
+      value: 7.4515533
       objectReference: {fileID: 0}
     - target: {fileID: -8123559110241969439, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: 0.737273
+      value: -0.33460665
       objectReference: {fileID: 0}
     - target: {fileID: -8123559110241969439, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Extent.x
-      value: 2.400498
+      value: 2.450694
       objectReference: {fileID: 0}
     - target: {fileID: -8123559110241969439, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Extent.y
-      value: 3.2366164
+      value: 3.096549
       objectReference: {fileID: 0}
     - target: {fileID: -7694217771748202108, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
@@ -363,22 +363,22 @@ PrefabInstance:
     - target: {fileID: -7578943176630698069, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Center.x
-      value: -3.8105226
+      value: 8.277773
       objectReference: {fileID: 0}
     - target: {fileID: -7578943176630698069, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: 2.8821344
+      value: -2.3574152
       objectReference: {fileID: 0}
     - target: {fileID: -7578943176630698069, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Extent.x
-      value: 5.133348
+      value: 6.082325
       objectReference: {fileID: 0}
     - target: {fileID: -7578943176630698069, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Extent.y
-      value: 5.543457
+      value: 3.3539114
       objectReference: {fileID: 0}
     - target: {fileID: -7552582706839291426, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
@@ -403,12 +403,12 @@ PrefabInstance:
     - target: {fileID: -7552582706839291426, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: -0.75
       objectReference: {fileID: 0}
     - target: {fileID: -7552582706839291426, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: -0.1
       objectReference: {fileID: 0}
     - target: {fileID: -7552582706839291426, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
@@ -483,22 +483,22 @@ PrefabInstance:
     - target: {fileID: -6367637884826946392, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Center.x
-      value: 5.393702
+      value: 8.852373
       objectReference: {fileID: 0}
     - target: {fileID: -6367637884826946392, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: -4.421691
+      value: -1.5529613
       objectReference: {fileID: 0}
     - target: {fileID: -6367637884826946392, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Extent.x
-      value: 5.4775825
+      value: 5.3673463
       objectReference: {fileID: 0}
     - target: {fileID: -6367637884826946392, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Extent.y
-      value: 2.7438526
+      value: 2.5856051
       objectReference: {fileID: 0}
     - target: {fileID: -6295874466816754212, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
@@ -788,62 +788,62 @@ PrefabInstance:
     - target: {fileID: -587020401536548690, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Center.x
-      value: -1.741322
+      value: 9.391716
       objectReference: {fileID: 0}
     - target: {fileID: -587020401536548690, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: -3.9753437
+      value: -0.014196396
       objectReference: {fileID: 0}
     - target: {fileID: -587020401536548690, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Extent.x
-      value: 3.9377484
+      value: 5.64308
       objectReference: {fileID: 0}
     - target: {fileID: -587020401536548690, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Extent.y
-      value: 6.556797
+      value: 4.386397
       objectReference: {fileID: 0}
     - target: {fileID: -198828038849347438, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Center.x
-      value: 6.074504
+      value: 7.567542
       objectReference: {fileID: 0}
     - target: {fileID: -198828038849347438, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: -1.5640125
+      value: -0.6102295
       objectReference: {fileID: 0}
     - target: {fileID: -198828038849347438, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Extent.x
-      value: 3.2240667
+      value: 2.5026999
       objectReference: {fileID: 0}
     - target: {fileID: -198828038849347438, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Extent.y
-      value: 2.6864157
+      value: 3.052894
       objectReference: {fileID: 0}
     - target: {fileID: 135192302097971356, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Center.x
-      value: 7.0350466
+      value: 8.47148
       objectReference: {fileID: 0}
     - target: {fileID: 135192302097971356, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: -0.94979525
+      value: 0.08483505
       objectReference: {fileID: 0}
     - target: {fileID: 135192302097971356, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Extent.x
-      value: 11.389415
+      value: 8.136705
       objectReference: {fileID: 0}
     - target: {fileID: 135192302097971356, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Extent.y
-      value: 5.1349516
+      value: 6.3326178
       objectReference: {fileID: 0}
     - target: {fileID: 152889754326694146, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
@@ -943,22 +943,22 @@ PrefabInstance:
     - target: {fileID: 3458939219845311056, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Center.x
-      value: 8.726291
+      value: 8.145655
       objectReference: {fileID: 0}
     - target: {fileID: 3458939219845311056, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: -2.200294
+      value: 0.09778023
       objectReference: {fileID: 0}
     - target: {fileID: 3458939219845311056, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Extent.x
-      value: 2.7037687
+      value: 2.207988
       objectReference: {fileID: 0}
     - target: {fileID: 3458939219845311056, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Extent.y
-      value: 1.5892464
+      value: 2.237784
       objectReference: {fileID: 0}
     - target: {fileID: 3654695972333542323, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
@@ -1123,22 +1123,22 @@ PrefabInstance:
     - target: {fileID: 8786841846783098033, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Center.x
-      value: 5.286636
+      value: 9.705656
       objectReference: {fileID: 0}
     - target: {fileID: 8786841846783098033, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Center.y
-      value: -0.35815787
+      value: -0.21712732
       objectReference: {fileID: 0}
     - target: {fileID: 8786841846783098033, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Extent.x
-      value: 1.8260903
+      value: 1.731065
       objectReference: {fileID: 0}
     - target: {fileID: 8786841846783098033, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}
       propertyPath: m_Bounds.m_Extent.y
-      value: 2.323567
+      value: 2.5260725
       objectReference: {fileID: 0}
     - target: {fileID: 9204824962387936881, guid: 4fb49310de99bf94fa2454847fd89525,
         type: 3}


### PR DESCRIPTION
다른 장면에서 모델 프리펩을 사용하기 위한 선행 조정 작업